### PR TITLE
build separate libopenh264 common, processing, encoder, decoder

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - if: ${{ needs_external_nasm }}
+      - if: ${{ matrix.needs_external_nasm }}
         name: Setup NASM
         uses: ilammy/setup-nasm@v1
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build:
-    name: build / linux / zig ${{ matrix.zig-version }}
+    name: build / ${{ matrix.os }} / zig ${{ matrix.zig-version }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,13 +11,13 @@ on:
 
 jobs:
   build:
-    name: build / ${{ matrix.os }} / zig ${{ matrix.zig-version }}
+    name: build / linux / zig ${{ matrix.zig-version }}
 
     strategy:
       fail-fast: false
       matrix:
         zig-version: ["master", "0.13.0"]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,12 +17,19 @@ jobs:
       fail-fast: false
       matrix:
         zig-version: ["master", "0.13.0"]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        include:
+          - os: windows-latest
+            needs_external_nasm: true
 
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+
+      - if: ${{ needs_external_nasm }}
+        name: Setup NASM
+        uses: ilammy/setup-nasm@v1
 
       - name: Setup Zig
         uses: mlugg/setup-zig@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,32 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: build / ${{ matrix.os }} / zig ${{ matrix.zig-version }}
+
+    strategy:
+      matrix:
+        zig-version: ["master", "0.13.0"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Zig
+        uses: mlugg/setup-zig@v1
+        with:
+          version: ${{ matrix.zig-version }}
+
+      - name: Build
+        run: zig build --release=fast --summary all

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,7 @@ jobs:
     name: build / ${{ matrix.os }} / zig ${{ matrix.zig-version }}
 
     strategy:
+      fail-fast: false
       matrix:
         zig-version: ["master", "0.13.0"]
         os: [ubuntu-latest, macos-latest, windows-latest]

--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ your_compilation.linkLibrary(openh264_dep.artifact("openh264"));
 This will provide OpenH264 as a static library to `your_compilation` without the
 included bindings.
 
+## Known Issues
+
+* Windows is not supported since the Zig `nasm` dependency [does not work on
+Windows](https://github.com/allyourcodebase/nasm/issues/3) at this time.
+
 ## Contribute
 
 This repo is a stripped down version of the original OpenH264 repository:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,39 @@ First, update your `build.zig.zon`:
 zig fetch --save git+https://github.com/gerwin3/openh264.git
 ```
 
-Next, add this snippet to your `build.zig` script:
+### To use the Zig-friendly bindings
+
+Add this snippet to your `build.zig` script:
+
+```zig
+const openh264_dep = b.dependency("openh264", .{
+    .target = target,
+    .optimize = optimize,
+});
+your_compilation.root_module.addImport("openh264", openh264_dep.module("openh264"));
+```
+
+You can now import and use the `openh264` module. See the `examples` directory
+for usage. This will automatically link the OpenH264 library.
+
+### To use the raw bindings
+
+Add this snippet to your `build.zig` script:
+
+```zig
+const openh264_dep = b.dependency("openh264", .{
+    .target = target,
+    .optimize = optimize,
+});
+your_compilation.root_module.addImport("openh264_bindings", openh264_dep.module("openh264_bindings"));
+```
+
+You can now import and use the `openh264_bindings` module. See the `examples`
+directory for usage. This will automatically link the OpenH264 library.
+
+### To use the static OpenH264 library without bindings
+
+Add this snippet to your `build.zig` script:
 
 ```zig
 const openh264_dep = b.dependency("openh264", .{
@@ -21,9 +53,8 @@ const openh264_dep = b.dependency("openh264", .{
 your_compilation.linkLibrary(openh264_dep.artifact("openh264"));
 ```
 
-This will provide OpenH264 as a static library to `your_compilation`.
-
-TODO: About openh264 module and openh264_bindings module.
+This will provide OpenH264 as a static library to `your_compilation` without the
+included bindings.
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 This is [OpenH264](https://github.com/cisco/openh264), packaged for
 [Zig](https://ziglang.org/).
 
+## Status
+
+
+
 ## Installation
 
 First, update your `build.zig.zon`:

--- a/README.md
+++ b/README.md
@@ -3,9 +3,23 @@
 This is [OpenH264](https://github.com/cisco/openh264), packaged for
 [Zig](https://ziglang.org/).
 
-## Status
+## Support
 
+| Architecture / OS | Linux | MacOS | Windows |
+|-------------------|-------|-------|---------|
+| x86               | ✅    | ✅    | ✅      |
+| x86_64            | ✅    | ✅    | ✅      |
+| arm               | ✅    | ✅    | ✅      |
+| aarch64           | ✅    | ✅    | ✅      |
 
+> [!NOTE]  
+> On Windows, NASM must be installed. On Linux and macOS NASM is automatically compiled as part of the build.
+
+| Zig version | Stauts |
+|-------------|--------|
+| zig 12.0.0  | ✅     |
+| zig 12.0.1  | ✅     |
+| zig 13.0.0  | ✅     |
 
 ## Installation
 

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "2.5.0-423eb2c3e47009f4e631b5e413123a003fdff1ed",
     .dependencies = .{
         .nasm = .{
-            .url = "https://github.com/allyourcodebase/nasm/archive/refs/tags/2.16.1-3.tar.gz",
-            .hash = "12200a9194f9cdd05e9ff23729f4ed0e54f51abe09bd6eaf61b58609791647b141d2",
+            .url = "git+https://github.com/gerwin3/nasm.git#d8fea798df035e6e48b3ee504ab2aa7dafe5e750",
+            .hash = "12204ecbc8803918c49728d5c3b2f63f5cc8186835692f6121ae97324db153c927ba",
         },
     },
     .paths = .{

--- a/codec/api/wels/codec_app_def.h
+++ b/codec/api/wels/codec_app_def.h
@@ -592,6 +592,9 @@ typedef struct TagEncParamExt {
   bool    bIsLosslessLink;             ///< LTR advanced setting
   bool    bFixRCOverShoot;             ///< fix rate control overshooting
   int     iIdrBitrateRatio;            ///< the target bits of IDR is (idr_bitrate_ratio/100) * average target bit per frame.
+  bool    bPsnrY;                      ///< get Y PSNR stats for the whole video sequence
+  bool    bPsnrU;                      ///< get U PSNR stats for the whole video sequence
+  bool    bPsnrV;                      ///< get V PSNR stats for the whole video sequence
 } SEncParamExt;
 
 /**
@@ -635,6 +638,7 @@ typedef struct {
   int   iNalCount;              ///< count number of NAL coded already
   int*  pNalLengthInByte;       ///< length of NAL size in byte from 0 to iNalCount-1
   unsigned char*  pBsBuf;       ///< buffer of bitstream contained
+  float rPsnr[3];               ///< PSNR values for Y/U/V
 } SLayerBSInfo, *PLayerBSInfo;
 
 /**
@@ -659,7 +663,11 @@ typedef struct Source_Picture_s {
   int       iPicWidth;             ///< luma picture width in x coordinate
   int       iPicHeight;            ///< luma picture height in y coordinate
   long long uiTimeStamp;           ///< timestamp of the source picture, unit: millisecond
+  bool      bPsnrY;                ///< get Y PSNR for this frame
+  bool      bPsnrU;                ///< get U PSNR for this frame
+  bool      bPsnrV;                ///< get V PSNR for this frame
 } SSourcePicture;
+
 /**
 * @brief Structure for bit rate info
 */

--- a/codec/encoder/core/inc/as264_common.h
+++ b/codec/encoder/core/inc/as264_common.h
@@ -74,7 +74,6 @@ $(TargetPath)
 #endif//ENABLE_FRAME_DUMP
 #endif//__UNITTEST__
 
-//#define ENABLE_PSNR_CALC
 //#define STAT_OUTPUT
 //#define MB_TYPES_CHECK
 //
@@ -87,10 +86,6 @@ $(TargetPath)
 /* macros dependencies check */
 //@if !FRAME_INFO_OUTPUT
 #if !defined(FRAME_INFO_OUTPUT)
-
-#if defined(ENABLE_PSNR_CALC)
-#undef ENABLE_PSNR_CALC
-#endif//ENABLE_PSNR_CALC
 
 //#if defined(STAT_OUTPUT)
 //#undef STAT_OUTPUT

--- a/codec/encoder/core/inc/param_svc.h
+++ b/codec/encoder/core/inc/param_svc.h
@@ -180,6 +180,9 @@ typedef struct TagWelsSvcCodingParam: SEncParamExt {
     param.bIsLosslessLink = false;
     param.bFixRCOverShoot = true;
     param.iIdrBitrateRatio = IDR_BITRATE_RATIO * 100;
+    param.bPsnrY = false;
+    param.bPsnrU = false;
+    param.bPsnrV = false;
     for (int32_t iLayer = 0; iLayer < MAX_SPATIAL_LAYER_NUM; iLayer++) {
       param.sSpatialLayers[iLayer].uiProfileIdc = PRO_UNKNOWN;
       param.sSpatialLayers[iLayer].uiLevelIdc = LEVEL_UNKNOWN;
@@ -345,6 +348,9 @@ typedef struct TagWelsSvcCodingParam: SEncParamExt {
     bIsLosslessLink = pCodingParam.bIsLosslessLink;
     bFixRCOverShoot = pCodingParam.bFixRCOverShoot;
     iIdrBitrateRatio = pCodingParam.iIdrBitrateRatio;
+    bPsnrY = pCodingParam.bPsnrY;
+    bPsnrU = pCodingParam.bPsnrU;
+    bPsnrV = pCodingParam.bPsnrV;
     if (iUsageType == SCREEN_CONTENT_REAL_TIME && !bIsLosslessLink && bEnableLongTermReference) {
       bEnableLongTermReference = false;
     }

--- a/codec/encoder/core/src/encoder_ext.cpp
+++ b/codec/encoder/core/src/encoder_ext.cpp
@@ -2186,7 +2186,7 @@ void StatOverallEncodingExt (sWelsEncCtx* pCtx) {
 
   }
 }
-#endif
+#endif //#if defined(STAT_OUTPUT)
 
 
 int32_t GetMultipleThreadIdc (SLogContext* pLogCtx, SWelsSvcCodingParam* pCodingParam, int16_t& iSliceNum,
@@ -3445,9 +3445,7 @@ int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, SFrameBSInfo* pFbi, const SSour
   SLayerBSInfo* pLayerBsInfo            = &pFbi->sLayerInfo[0];
   SWelsSvcCodingParam* pSvcParam        = pCtx->pSvcParam;
   SSpatialPicIndex* pSpatialIndexMap = &pCtx->sSpatialIndexMap[0];
-#if defined(ENABLE_FRAME_DUMP) || defined(ENABLE_PSNR_CALC)
   SPicture* fsnr                = NULL;
-#endif//ENABLE_FRAME_DUMP || ENABLE_PSNR_CALC
   SPicture* pEncPic             = NULL; // to be decided later
 #if defined(MT_DEBUG)
   int32_t iDidList[MAX_DEPENDENCY_LAYER] = {0};
@@ -3469,9 +3467,7 @@ int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, SFrameBSInfo* pFbi, const SSour
   int32_t iCurTid                = 0;
   bool bAvcBased                = false;
   SLogContext* pLogCtx = & (pCtx->sLogCtx);
-#if defined(ENABLE_PSNR_CALC)
   float fSnrY = .0f, fSnrU = .0f, fSnrV = .0f;
-#endif//ENABLE_PSNR_CALC
 
 #if defined(_DEBUG)
   int32_t i = 0, j = 0, k = 0;
@@ -3624,9 +3620,7 @@ int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, SFrameBSInfo* pFbi, const SSour
     pCtx->eNalPriority = eNalRefIdc;
 
     pCtx->pDecPic               = pCtx->ppRefPicListExt[iCurDid]->pNextBuffer;
-#if defined(ENABLE_FRAME_DUMP) || defined(ENABLE_PSNR_CALC)
     fsnr                        = pCtx->pDecPic;
-#endif//#if defined(ENABLE_FRAME_DUMP) || defined(ENABLE_PSNR_CALC)
     pCtx->pDecPic->iPictureType = pCtx->eSliceType;
     pCtx->pDecPic->iFramePoc    = pParamInternal->iPOC;
 
@@ -3921,26 +3915,30 @@ int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, SFrameBSInfo* pFbi, const SSour
     }
 #endif//ENABLE_FRAME_DUMP
 
-#if defined(ENABLE_PSNR_CALC)
-    fSnrY = WelsCalcPsnr (fsnr->pData[0],
-                          fsnr->iLineSize[0],
-                          pEncPic->pData[0],
-                          pEncPic->iLineSize[0],
-                          iCurWidth,
-                          iCurHeight);
-    fSnrU = WelsCalcPsnr (fsnr->pData[1],
-                          fsnr->iLineSize[1],
-                          pEncPic->pData[1],
-                          pEncPic->iLineSize[1],
-                          (iCurWidth >> 1),
-                          (iCurHeight >> 1));
-    fSnrV = WelsCalcPsnr (fsnr->pData[2],
-                          fsnr->iLineSize[2],
-                          pEncPic->pData[2],
-                          pEncPic->iLineSize[2],
-                          (iCurWidth >> 1),
-                          (iCurHeight >> 1));
-#endif//ENABLE_PSNR_CALC
+    if (fsnr && (pSvcParam->bPsnrY || pSrcPic->bPsnrY)) {
+      fSnrY = WelsCalcPsnr (fsnr->pData[0],
+                            fsnr->iLineSize[0],
+                            pEncPic->pData[0],
+                            pEncPic->iLineSize[0],
+                            iCurWidth,
+                            iCurHeight);
+    }
+    if (fsnr && (pSvcParam->bPsnrU || pSrcPic->bPsnrU)) {
+      fSnrU = WelsCalcPsnr (fsnr->pData[1],
+                            fsnr->iLineSize[1],
+                            pEncPic->pData[1],
+                            pEncPic->iLineSize[1],
+                            (iCurWidth >> 1),
+                            (iCurHeight >> 1));
+    }
+    if (fsnr && (pSvcParam->bPsnrV || pSrcPic->bPsnrV)) {
+      fSnrV = WelsCalcPsnr (fsnr->pData[2],
+                            fsnr->iLineSize[2],
+                            pEncPic->pData[2],
+                            pEncPic->iLineSize[2],
+                            (iCurWidth >> 1),
+                            (iCurHeight >> 1));
+    }
 
 #if defined(LAYER_INFO_OUTPUT)
     fprintf (stderr, "%2s %5d: %-5d %2s   T%1d D%1d Q%-2d  QP%3d   Y%2.2f  U%2.2f  V%2.2f  %8d bits\n",
@@ -3958,15 +3956,32 @@ int32_t WelsEncoderEncodeExt (sWelsEncCtx* pCtx, SFrameBSInfo* pFbi, const SSour
              (iLayerSize << 3));
 #endif//LAYER_INFO_OUTPUT
 
+    pLayerBsInfo->rPsnr[0] = NAN;
+    pLayerBsInfo->rPsnr[1] = NAN;
+    pLayerBsInfo->rPsnr[2] = NAN;
+    if (pSrcPic->bPsnrY) {
+      pLayerBsInfo->rPsnr[0] = fSnrY;
+    }
+    if (pSrcPic->bPsnrU) {
+      pLayerBsInfo->rPsnr[1] = fSnrU;
+    }
+    if (pSrcPic->bPsnrV) {
+      pLayerBsInfo->rPsnr[2] = fSnrV;
+    }
+
 #if defined(STAT_OUTPUT)
 
-#if defined(ENABLE_PSNR_CALC)
     {
-      pCtx->sStatData[iCurDid][0].sQualityStat.rYPsnr[pCtx->eSliceType] += fSnrY;
-      pCtx->sStatData[iCurDid][0].sQualityStat.rUPsnr[pCtx->eSliceType] += fSnrU;
-      pCtx->sStatData[iCurDid][0].sQualityStat.rVPsnr[pCtx->eSliceType] += fSnrV;
+      if (pSvcParam->bPsnrY) {
+        pCtx->sStatData[iCurDid][0].sQualityStat.rYPsnr[pCtx->eSliceType] += fSnrY;
+      }
+      if (pSvcParam->bPsnrU) {
+        pCtx->sStatData[iCurDid][0].sQualityStat.rUPsnr[pCtx->eSliceType] += fSnrU;
+      }
+      if (pSvcParam->bPsnrV) {
+        pCtx->sStatData[iCurDid][0].sQualityStat.rVPsnr[pCtx->eSliceType] += fSnrV;
+      }
     }
-#endif//ENABLE_PSNR_CALC
 
 #if defined(MB_TYPES_CHECK) //091025, frame output
     if (pCtx->eSliceType == P_SLICE) {

--- a/examples/encode_rainbow_low_level.zig
+++ b/examples/encode_rainbow_low_level.zig
@@ -82,6 +82,7 @@ pub fn main() !void {
         @memset(picture_data.y, r.y);
         @memset(picture_data.u, r.u);
         @memset(picture_data.v, r.v);
+        std.debug.print("{}, {}, {}\n", .{ r.y, r.u, r.v }); // TODO
         rc = encoder.?.*.?.*.EncodeFrame.?(encoder, &picture, &info);
         std.debug.assert(rc == 0);
         std.debug.assert(info.eFrameType != .invalid);

--- a/openh264_bindings.zig
+++ b/openh264_bindings.zig
@@ -426,6 +426,7 @@ pub const SFrameBSInfo = extern struct {
     eFrameType: EVideoFrameType,
     iFrameSizeInBytes: c_int,
     uiTimeStamp: c_longlong,
+    rPsnr: [3]f32,
 };
 
 pub const SLayerBSInfo = extern struct {
@@ -457,6 +458,9 @@ pub const SSourcePicture = extern struct {
     iPicWidth: c_int,
     iPicHeight: c_int,
     uiTimeStamp: c_longlong,
+    bPsnrY: bool = false,
+    bPsnrU: bool = false,
+    bPsnrV: bool = false,
 };
 
 pub const SVideoProperty = extern struct {


### PR DESCRIPTION
Build on Windows fails currently since the object merge approach we were using does not work.

This branch also has issues:

- [ ] Encoder demos only work when the bindings are compiled in release mode (previously the libs were in release mode always but it did not matter for the wrapper)
- [ ] Decoder demo just does not run